### PR TITLE
Added mqtts support

### DIFF
--- a/cmd/distro/main.go
+++ b/cmd/distro/main.go
@@ -23,8 +23,8 @@ import (
 const (
 	envClientHost string = "EXPORT_DISTRO_CLIENT_HOST"
 	envDataHost   string = "EXPORT_DISTRO_DATA_HOST"
-	envMQTTSCert  string = "MQTTS_CERT_FILE"
-	envMQTTSKey   string = "MQTTS_KEY_FILE"
+	envMQTTSCert  string = "EXPORT_DISTRO_MQTTS_CERT_FILE"
+	envMQTTSKey   string = "EXPORT_DISTRO_MQTTS_KEY_FILE"
 )
 
 var logger *zap.Logger

--- a/cmd/distro/main.go
+++ b/cmd/distro/main.go
@@ -23,6 +23,8 @@ import (
 const (
 	envClientHost string = "EXPORT_DISTRO_CLIENT_HOST"
 	envDataHost   string = "EXPORT_DISTRO_DATA_HOST"
+	envMQTTSCert  string = "MQTTS_CERT_FILE"
+	envMQTTSKey   string = "MQTTS_KEY_FILE"
 )
 
 var logger *zap.Logger
@@ -57,6 +59,8 @@ func loadConfig() distro.Config {
 	cfg := distro.GetDefaultConfig()
 	cfg.ClientHost = env(envClientHost, cfg.ClientHost)
 	cfg.DataHost = env(envDataHost, cfg.DataHost)
+	cfg.MQTTSCert = env(envMQTTSCert, cfg.MQTTSCert)
+	cfg.MQTTSKey = env(envMQTTSKey, cfg.MQTTSKey)
 	return cfg
 }
 

--- a/distro/http.go
+++ b/distro/http.go
@@ -29,7 +29,7 @@ func NewHTTPSender(addr models.Addressable) Sender {
 	// CHN: Should be added protocol from Addressable instead of include it the address param.
 	// CHN: We will maintain this behaviour for compatibility with Java
 	sender := httpSender{
-		url:    addr.Address + ":" + strconv.Itoa(addr.Port) + addr.Path,
+		url:    addr.Protocol + "://" + addr.Address + ":" + strconv.Itoa(addr.Port) + addr.Path,
 		method: addr.HTTPMethod,
 	}
 	return sender

--- a/distro/http.go
+++ b/distro/http.go
@@ -26,8 +26,7 @@ const mimeTypeJSON = "application/json"
 
 // NewHTTPSender - create http sender
 func NewHTTPSender(addr models.Addressable) Sender {
-	// CHN: Should be added protocol from Addressable instead of include it the address param.
-	// CHN: We will maintain this behaviour for compatibility with Java
+
 	sender := httpSender{
 		url:    addr.Protocol + "://" + addr.Address + ":" + strconv.Itoa(addr.Port) + addr.Path,
 		method: addr.HTTPMethod,

--- a/distro/mqtt.go
+++ b/distro/mqtt.go
@@ -43,8 +43,7 @@ func NewMqttSender(addr models.Addressable) Sender {
 		cert, err := tls.LoadX509KeyPair(cfg.MQTTSCert, cfg.MQTTSKey)
 
 		if err != nil {
-			logger.Fatal("Failed loading x509 data")
-			return nil
+			logger.Error("Failed loading x509 data")
 		}
 
 		tlsConfig := &tls.Config{

--- a/distro/mqtt.go
+++ b/distro/mqtt.go
@@ -9,7 +9,9 @@
 package distro
 
 import (
+	"crypto/tls"
 	"strconv"
+	"strings"
 
 	MQTT "github.com/eclipse/paho.mqtt.golang"
 	"github.com/edgexfoundry/core-domain-go/models"
@@ -23,13 +25,37 @@ type mqttSender struct {
 
 // NewMqttSender - create new mqtt sender
 func NewMqttSender(addr models.Addressable) Sender {
+
+	protocol := strings.ToLower(addr.Protocol)
+
 	opts := MQTT.NewClientOptions()
-	broker := "tcp://" + addr.Address + ":" + strconv.Itoa(addr.Port)
+	broker := protocol + "://" + addr.Address + ":" + strconv.Itoa(addr.Port) + addr.Path
 	opts.AddBroker(broker)
 	opts.SetClientID(addr.Publisher)
 	opts.SetUsername(addr.User)
 	opts.SetPassword(addr.Password)
 	opts.SetAutoReconnect(false)
+
+	if protocol == "tcps" ||
+		protocol == "ssl" ||
+		protocol == "tls" {
+
+		cert, err := tls.LoadX509KeyPair(cfg.MQTTSCert, cfg.MQTTSKey)
+
+		if err != nil {
+			logger.Fatal("Failed loading x509 data")
+			return nil
+		}
+
+		tlsConfig := &tls.Config{
+			ClientCAs:          nil,
+			InsecureSkipVerify: true,
+			Certificates:       []tls.Certificate{cert},
+		}
+
+		opts.SetTLSConfig(tlsConfig)
+
+	}
 
 	sender := &mqttSender{
 		client: MQTT.NewClient(opts),
@@ -43,7 +69,7 @@ func (sender *mqttSender) Send(data []byte) {
 	if !sender.client.IsConnected() {
 		logger.Info("Connecting to mqtt server")
 		if token := sender.client.Connect(); token.Wait() && token.Error() != nil {
-			logger.Warn("Could not connect to mqtt server, drop event")
+			logger.Warn("Could not connect to mqtt server, drop event", zap.Error(token.Error()))
 			return
 		}
 	}

--- a/distro/registrations.go
+++ b/distro/registrations.go
@@ -90,6 +90,11 @@ func (reg *registrationInfo) update(newReg export.Registration) bool {
 		logger.Warn("Destination not supported: ", zap.String("destination", newReg.Destination))
 		return false
 	}
+
+	if reg.sender == nil {
+		return false
+	}
+
 	reg.encrypt = nil
 	switch newReg.Encryption.Algo {
 	case export.EncNone:

--- a/distro/registrations.go
+++ b/distro/registrations.go
@@ -17,8 +17,10 @@ import (
 	"net/http"
 	"time"
 
+	export "github.com/edgexfoundry/export-go"
+
 	"github.com/edgexfoundry/core-domain-go/models"
-	"github.com/edgexfoundry/export-go"
+
 	"go.uber.org/zap"
 )
 

--- a/distro/types.go
+++ b/distro/types.go
@@ -10,13 +10,15 @@ package distro
 
 import (
 	"github.com/edgexfoundry/core-domain-go/models"
-	"github.com/edgexfoundry/export-go"
+	export "github.com/edgexfoundry/export-go"
 )
 
 const (
 	defaultPort       = 48070
 	defaultClientHost = "127.0.0.1"
 	defaultDataHost   = "127.0.0.1"
+	defaultMQTTSCert  = "dummy.crt"
+	defaultMQTTSKey   = "dummy.key"
 )
 
 // Sender - Send interface
@@ -58,6 +60,8 @@ type Config struct {
 	Port       int
 	ClientHost string
 	DataHost   string
+	MQTTSCert  string
+	MQTTSKey   string
 }
 
 var cfg Config
@@ -67,5 +71,7 @@ func GetDefaultConfig() Config {
 		Port:       defaultPort,
 		ClientHost: defaultClientHost,
 		DataHost:   defaultDataHost,
+		MQTTSCert:  defaultMQTTSCert,
+		MQTTSKey:   defaultMQTTSKey,
 	}
 }


### PR DESCRIPTION
Added two environment variables to define where cert and key are.

EXPORT_DISTRO_MQTTS_CERT_FILE
EXPORT_DISTRO_MQTTS_KEY_FILE

And following the same behaviour as other env variables, and can be overwritten by consul configuration.

Signed-off-by: chencho <smunoz@caviumnetworks.com>